### PR TITLE
feature: add grades and skills relationships to employees for client endpoint

### DIFF
--- a/migrations/027_employee_grades.js
+++ b/migrations/027_employee_grades.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema
+    .alterTable('employees', function(table) {
+      table.string('grade_code')
+
+      table.foreign('grade_code').references('grades.grade_code')
+    });
+};
+exports.down = function(knex) {
+  return knex.schema
+    .alterTable('employees', function(table) {
+      table.dropForeign('grade_code')
+      table.dropColumn('grade_code')
+  });
+};

--- a/migrations/028_employees_skill.js
+++ b/migrations/028_employees_skill.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('employees_skills', function(table) {
+      table.integer('perdet_seq_num')
+      table.integer('jc_id')
+
+      table.foreign('perdet_seq_num').references('employees.perdet_seq_num')
+      table.foreign('jc_id').references('codes.jc_id')
+    });
+};
+exports.down = function(knex) {
+  return knex.schema
+    .dropTable('employees_skills');
+};

--- a/migrations/029_employees_manager.js
+++ b/migrations/029_employees_manager.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema
+    .alterTable('employees', function(table) {
+      table.integer('manager_id')
+
+      table.foreign('manager_id').references('employees.perdet_seq_num')
+    });
+};
+exports.down = function(knex) {
+  return knex.schema
+    .alterTable('employees', function(table) {
+      table.dropForeign('manager_id')
+      table.dropColumn('manager_id')
+  });
+};

--- a/seeds/013_employees_skills_seed.js
+++ b/seeds/013_employees_skills_seed.js
@@ -1,0 +1,12 @@
+const { readJson } = require('./data/helpers')
+
+const employees_skills = readJson('./employees_skills.json')
+
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex.raw('TRUNCATE TABLE employees_skills CASCADE')
+    .then(function () {
+      // Inserts seed entries
+      return knex('employees_skills').insert(employees_skills);
+    });
+};

--- a/seeds/data/employees.json
+++ b/seeds/data/employees.json
@@ -15,7 +15,8 @@
     "role": "fsofficer",
     "fullname": "Jenny Townpost",
     "email": "jtownpost@talentmapmock.test",
-    "hru_id": 2
+    "hru_id": 2,
+    "grade_code": "00"
   },
   {
     "username": "shadtrachl",
@@ -24,7 +25,8 @@
     "role": "CDO",
     "fullname": "Leah Shadtrach",
     "email": "lshadtrach@talentmapmock.test",
-    "hru_id": 3
+    "hru_id": 3,
+    "grade_code": "01"
   },
   {
     "username": "rehmant",
@@ -33,7 +35,8 @@
     "role": "fsofficer",
     "fullname": "Tarek Rehman",
     "email": "trehman@talentmapmock.test",
-    "hru_id": 4
+    "hru_id": 4,
+    "grade_code": "02"
   },
   {
     "username": "woodwardw",
@@ -42,7 +45,8 @@
     "role": "CDO3",
     "fullname": "Wendy Woodward",
     "email": "wwoodward@talentmapmock.test",
-    "hru_id": 5
+    "hru_id": 5,
+    "grade_code": "03"
   },
   {
     "username": "finleyj",
@@ -51,7 +55,8 @@
     "role": "CDO",
     "fullname": "FINLEY,JOSEPH",
     "email": "finleyj@state.gov",
-    "hru_id": 246
+    "hru_id": 246,
+    "grade_code": "04"
   },
   {
     "username": "huxleye",
@@ -60,7 +65,8 @@
     "role": "fsofficer",
     "fullname": "HUXLEY,ELIZABETH",
     "email": "huxleye@state.gov",
-    "hru_id": 856
+    "hru_id": 856,
+    "grade_code": "05"
   },
   {
     "username": "johnsonm",
@@ -69,7 +75,8 @@
     "role": "AO",
     "fullname": "JOHNSON,MARQUISE",
     "email": "johnsonm@state.gov",
-    "hru_id": 249
+    "hru_id": 249,
+    "grade_code": "OM"
   },
   {
     "username": "kimj",
@@ -78,7 +85,8 @@
     "role": "PT",
     "fullname": "KIM,JOHN",
     "email": "kimj@state.gov",
-    "hru_id": 100
+    "hru_id": 100,
+    "grade_code": "08"
   },
   {
     "username": "lincolna",
@@ -87,7 +95,8 @@
     "role": "BMTSOD",
     "fullname": "LINCOLN,ABIGAIL",
     "email": "lincolna@state.gov",
-    "hru_id": 5001
+    "hru_id": 5001,
+    "grade_code": "08"
   },
   {
     "username": "nunesa",
@@ -96,7 +105,8 @@
     "role": "EMP",
     "fullname": "NUNES,ADELLE",
     "email": "nunesa@state.gov",
-    "hru_id": 1776
+    "hru_id": 1776,
+    "grade_code": "MC"
   },
   {
     "username": "petersj",
@@ -105,6 +115,7 @@
     "role": "CDO",
     "fullname": "PETERS,JEREMY",
     "email": "petersj@state.gov",
-    "hru_id": 9001
+    "hru_id": 9001,
+    "grade_code": "OC"
   }
 ]

--- a/seeds/data/employees.json
+++ b/seeds/data/employees.json
@@ -16,7 +16,8 @@
     "fullname": "Jenny Townpost",
     "email": "jtownpost@talentmapmock.test",
     "hru_id": 2,
-    "grade_code": "00"
+    "grade_code": "00",
+    "manager_id": 7
   },
   {
     "username": "shadtrachl",
@@ -36,7 +37,8 @@
     "fullname": "Tarek Rehman",
     "email": "trehman@talentmapmock.test",
     "hru_id": 4,
-    "grade_code": "02"
+    "grade_code": "02",
+    "manager_id": 7
   },
   {
     "username": "woodwardw",
@@ -66,7 +68,8 @@
     "fullname": "HUXLEY,ELIZABETH",
     "email": "huxleye@state.gov",
     "hru_id": 856,
-    "grade_code": "05"
+    "grade_code": "05",
+    "manager_id": 9
   },
   {
     "username": "johnsonm",

--- a/seeds/data/employees_skills.json
+++ b/seeds/data/employees_skills.json
@@ -1,0 +1,42 @@
+[
+  {
+    "perdet_seq_num": 6,
+    "jc_id": 2
+  },
+  {
+    "perdet_seq_num": 6,
+    "jc_id": 4
+  },
+  {
+    "perdet_seq_num": 4,
+    "jc_id": 6
+  },
+  {
+    "perdet_seq_num": 7,
+    "jc_id": 2
+  },
+  {
+    "perdet_seq_num": 6,
+    "jc_id": 1
+  },
+  {
+    "perdet_seq_num": 8,
+    "jc_id": 6
+  },
+  {
+    "perdet_seq_num": 14,
+    "jc_id": 8
+  },
+  {
+    "perdet_seq_num": 14,
+    "jc_id": 20
+  },
+  {
+    "perdet_seq_num": 14,
+    "jc_id": 11
+  },
+  {
+    "perdet_seq_num": 8,
+    "jc_id": 9
+  }
+]

--- a/src/models/codes.js
+++ b/src/models/codes.js
@@ -2,6 +2,7 @@ const bookshelf = require('../bookshelf.js')
 
 const Codes = bookshelf.model('Codes', {
   tableName: 'codes',
+  idAttribute: 'jc_id'
 })
 
 module.exports = Codes

--- a/src/models/employees.js
+++ b/src/models/employees.js
@@ -11,6 +11,9 @@ const Employees = bookshelf.model('Employees', {
   },
   skills() {
     return this.belongsToMany('Codes', 'employees_skills', 'perdet_seq_num', 'jc_id')
+  },
+  manager() {
+    return this.belongsTo('Employees', 'manager_id')
   }
 })
 

--- a/src/models/employees.js
+++ b/src/models/employees.js
@@ -2,10 +2,15 @@ const bookshelf = require('../bookshelf.js')
 
 const Employees = bookshelf.model('Employees', {
   tableName: 'employees',
-  idAttribute: 'hru_id',
+  idAttribute: 'perdet_seq_num',
   role() {
     return this.belongsTo('Roles', 'role')
-
+  },
+  grade() {
+    return this.belongsTo('Grades', 'grade')
+  },
+  skills() {
+    return this.belongsToMany('Codes', 'employees_skills', 'perdet_seq_num', 'jc_id')
   }
 })
 

--- a/src/models/grades.js
+++ b/src/models/grades.js
@@ -2,6 +2,7 @@ const bookshelf = require('../bookshelf.js')
 
 const Grades = bookshelf.model('Grades', {
   tableName: 'grades',
+  idAttribute: 'grade_code'
 })
 
 module.exports = Grades

--- a/src/routes.js
+++ b/src/routes.js
@@ -131,6 +131,16 @@ var appRouter = function (app) {
       return_code: 0
     })
   })
+
+  app.get('/Client/Clients', async function(req, res) {
+    const clients = await employees.get_clients(req.query)
+
+    res.status(200).send({
+      Data: clients,
+      usl_id: 0,
+      return_code: 0
+    })
+  })
 };
 
 module.exports = appRouter;

--- a/src/routes.js
+++ b/src/routes.js
@@ -122,7 +122,7 @@ var appRouter = function (app) {
   app.get('/skillCodes', lookup(lookups.get_codes))
   app.get('/Locations', lookup(lookups.get_locations))
 
-  app.get('/Client/Agents', async function(req, res) {
+  app.get('/Agents', async function(req, res) {
     const agents = await employees.get_agents(req.query)
 
     res.status(200).send({
@@ -132,7 +132,7 @@ var appRouter = function (app) {
     })
   })
 
-  app.get('/Client/Clients', async function(req, res) {
+  app.get('/Clients', async function(req, res) {
     const clients = await employees.get_clients(req.query)
 
     res.status(200).send({

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -29,7 +29,9 @@ const get_agents = async (query) => {
 }
 
 const get_clients = async (query) => {
+  const { ad_id } = query
   const q = {}
+  if (ad_id) q['manager.ad_id'] = ad_id
   const data = await get_employee_by_query(q)
   return data.map((emp, index) => {
     const [skill1 = {}, skill2 = {}, skill3 = {}] = emp.skills
@@ -55,8 +57,9 @@ const get_clients = async (query) => {
 const get_employee_by_query = async query => {
   try {
     const data = await Employees.query(qb => {
+      qb.join('employees as manager', 'employees.manager_id', 'manager.perdet_seq_num')
       qb.where(query)
-    }).fetchAll({ require: false, withRelated: ['role', 'skills']})
+    }).fetchAll({ require: false, withRelated: ['role', 'skills', 'manager']})
     return data.serialize()
   } catch (Error) {
     console.error(Error)

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -16,6 +16,8 @@ const get_agents = async (query) => {
     delete emp.perdet_seq_num
     delete emp.username
     delete emp.ad_id
+    delete emp.grade_code
+    delete emp.skills
     const { code: rolecode, description: rl_descr_txt } = emp.role
     delete emp.role
     return { 
@@ -26,12 +28,35 @@ const get_agents = async (query) => {
   })
 }
 
+const get_clients = async (query) => {
+  const q = {}
+  const data = await get_employee_by_query(q)
+  return data.map((emp, index) => {
+    const [skill1 = {}, skill2 = {}, skill3 = {}] = emp.skills
+    const { role, location = {}} = emp
+    return {
+      rnum: index + 1,
+      per_full_name: emp.fullname,
+      perdet_seq_num: emp.perdet_seq_num,
+      grade_code: emp.grade_code,
+      skill_code: skill1.skl_code,
+      skill_code_desc: skill1.skill_descr,
+      skill2_code: skill2.skl_code,
+      skill2_code_desc: skill2.skill_descr,
+      skill3_code: skill3.skl_code,
+      skill3_code_desc: skill3.skill_descr,
+      emplid: emp.username,
+      role_code: role.code,
+      pos_location_code: location.code
+    }
+  })
+}
+
 const get_employee_by_query = async query => {
   try {
     const data = await Employees.query(qb => {
-      qb.join('roles', 'employees.role', 'roles.code')
       qb.where(query)
-    }).fetchAll({ require: false, withRelated: ['role']})
+    }).fetchAll({ require: false, withRelated: ['role', 'skills']})
     return data.serialize()
   } catch (Error) {
     console.error(Error)
@@ -39,4 +64,4 @@ const get_employee_by_query = async query => {
   }
 }
 
-module.exports = { get_employee_by_ad_id, get_employee_by_perdet_seq_num, get_employee_by_username, get_agents }
+module.exports = { get_employee_by_ad_id, get_employee_by_perdet_seq_num, get_employee_by_username, get_agents, get_clients }

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -19,6 +19,7 @@ const get_agents = async (query) => {
     delete emp.grade_code
     delete emp.skills
     delete emp.manager
+    delete emp.manager_id
     const { code: rolecode, description: rl_descr_txt } = emp.role
     delete emp.role
     return { 
@@ -39,6 +40,7 @@ const get_clients = async (query) => {
     const { role, location = {}} = emp
     return {
       rnum: index + 1,
+      hru_id: emp.hru_id,
       per_full_name: emp.fullname,
       perdet_seq_num: emp.perdet_seq_num,
       grade_code: emp.grade_code,

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -1,16 +1,16 @@
 const { Employees } = require('../models')
 
-const get_employee_by_ad_id = async query => await get_employee_by_query({'ad_id': query.ad_id})
+const get_employee_by_ad_id = async query => await get_employee_by_query({'employees.ad_id': query.ad_id})
 
-const get_employee_by_username = async username => await get_employee_by_query({'username': username})
+const get_employee_by_username = async username => await get_employee_by_query({'employees.username': username})
 
-const get_employee_by_perdet_seq_num = async perdet_seq_num => await get_employee_by_query({'perdet_seq_num': perdet_seq_num})
+const get_employee_by_perdet_seq_num = async perdet_seq_num => await get_employee_by_query({'employees.perdet_seq_num': perdet_seq_num})
 
 const get_agents = async (query) => {
   const { rl_cd, perdet_seq_num } = query
   const q = {}
   if (rl_cd) q['roles.code'] = rl_cd
-  if (perdet_seq_num) q.perdet_seq_num = perdet_seq_num
+  if (perdet_seq_num) q['employees.perdet_seq_num'] = perdet_seq_num
   const data = await get_employee_by_query(q)
   return data.map(emp => {
     delete emp.perdet_seq_num
@@ -58,7 +58,7 @@ const get_clients = async (query) => {
 const get_employee_by_query = async query => {
   try {
     const data = await Employees.query(qb => {
-      qb.join('employees as manager', 'employees.manager_id', 'manager.perdet_seq_num')
+      qb.leftOuterJoin('employees as manager', 'employees.manager_id', 'manager.perdet_seq_num')
       qb.where(query)
     }).fetchAll({ require: false, withRelated: ['role', 'skills', 'manager']})
     return data.serialize()

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -18,6 +18,7 @@ const get_agents = async (query) => {
     delete emp.ad_id
     delete emp.grade_code
     delete emp.skills
+    delete emp.manager
     const { code: rolecode, description: rl_descr_txt } = emp.role
     delete emp.role
     return { 


### PR DESCRIPTION
2 new endpoints.

`/Client/Agents`
 * params
   * rl_cd - role code
   * perdet_seq_num - emp_id in the talentmap DB

`/Client/Clients`
 * params
    * ad_id - ad_id (from token) gets all Clients for the provided ad_id

