### PR TITLE
Match email between CDO list and JWT

### DIFF
--- a/seeds/data/employees.json
+++ b/seeds/data/employees.json
@@ -25,7 +25,7 @@
     "perdet_seq_num": 7,
     "role": "CDO",
     "fullname": "Leah Shadtrach",
-    "email": "lshadtrach@talentmapmock.test",
+    "email": "shadtrachl@state.gov",
     "hru_id": 3,
     "grade_code": "01"
   },


### PR DESCRIPTION
Need the email for Leah Shadtrach to match the email generated in `src/routes.js` in order to test CDO `isCurrentUser` functionality.

Not sure if this will require a re-seed on deployment to AWS.