### PR TITLE
join -> fullOuterJoin for unaccompaniedstatuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon --watch ./src \"npm start\"",
-    "test": "NODE_ENV=test node_modules/.bin/nyc mocha --exit",
+    "test": "NODE_ENV=test node_modules/.bin/nyc mocha --exit --timeout 20000",
     "migrate": "node_modules/.bin/knex migrate:latest",
     "rollback": "node_modules/.bin/knex migrate:rollback",
     "seed": "node_modules/.bin/knex seed:run"

--- a/src/services/common.js
+++ b/src/services/common.js
@@ -127,7 +127,7 @@ const createPositionQuery = (model, tableName, paramPrefix, query, isCount) => {
     qb.join('locations', 'positions.pos_location_code', 'locations.location_code')
     qb.join('bureaus', 'positions.bureau', 'bureaus.bur')
     qb.join('codes', 'positions.jc_id', 'codes.jc_id')
-    qb.join('unaccompaniedstatuses', 'locations.us_code', 'unaccompaniedstatuses.us_code')
+    qb.fullOuterJoin('unaccompaniedstatuses', 'locations.us_code', 'unaccompaniedstatuses.us_code')
     qb.join('capsuledescriptions', 'positions.pos_seq_num', 'capsuledescriptions.pos_seq_num')
     Object.keys(query).map(q => {
       const filter = getFilter(q)
@@ -178,7 +178,7 @@ const createTandemPositionQuery = (model, tableName, paramPrefix, query, isCount
     qb.join('locations', 'positions.pos_location_code', 'locations.location_code')
     qb.join('bureaus', 'positions.bureau', 'bureaus.bur')
     qb.join('codes', 'positions.jc_id', 'codes.jc_id')
-    qb.join('unaccompaniedstatuses', 'locations.us_code', 'unaccompaniedstatuses.us_code')
+    qb.fullOuterJoin('unaccompaniedstatuses', 'locations.us_code', 'unaccompaniedstatuses.us_code')
     qb.join('capsuledescriptions', 'positions.pos_seq_num', 'capsuledescriptions.pos_seq_num')
     Object.keys(query).map(q => {
       const tandemFilter = getTandemFilter(q, isTandemOne)


### PR DESCRIPTION
Fixes an issue where positions would not appear in search if their associated post had a `us_code` of `null`