### PR TITLE
Update/count tandem params

### DIFF
--- a/src/services/availablepositions.js
+++ b/src/services/availablepositions.js
@@ -173,7 +173,7 @@ async function get_available_position_by_id(id) {
 }
 
 async function get_available_positions_tandem(query) {
-  const isCount = query['request_params.get_count'] === 'true'
+  const isCount = query['request_params.count'] === 'true'
 
   if (isCount) {
     return await get_ap_tandem_count(query, isCount)
@@ -208,7 +208,7 @@ async function get_ap_tandem_count(query, isCount) {
   const dataTandemTwo = await create_tandem_query(query, isCount, false).count()
   const combinedCount = parseInt(dataTandemOne) + parseInt(dataTandemTwo)
   return {
-    "Data": [{ "count(1)": combinedCount }],
+    "Data": [{ "cnt": combinedCount }],
     "usl_id": 44999637,
     "return_code": 0
   }

--- a/src/services/futurevacancies.js
+++ b/src/services/futurevacancies.js
@@ -124,7 +124,7 @@ async function get_future_vacancies_count(query) {
 }
 
 async function get_future_vacancies_tandem(query) {
-  const isCount = query['fv_request_params.get_count'] === 'true'
+  const isCount = query['request_params.count'] === 'true'
 
   if (isCount) {
     return await get_fv_tandem_count(query, isCount)
@@ -160,7 +160,7 @@ async function get_fv_tandem_count(query, isCount) {
   const dataTandemTwo = await create_tandem_query(query, isCount, false).count()
   const combinedCount = parseInt(dataTandemOne) + parseInt(dataTandemTwo)
   return {
-    "Data": [{ "count(1)": combinedCount }],
+    "Data": [{ "cnt": combinedCount }],
     "usl_id": 44999637,
     "return_code": 0
   }


### PR DESCRIPTION
- Accepted count param for both AP/PV is `prefix.count`
- Payload response is `cnt: #` 

NOTE: The count is off for tandem right now - it returns a number, but remember that tandem count is calculated by actually running the queries and checking the length of each query and combining them. I assume the query that is running in the count function is not taking into account the duplicate model objects with slightly different cpn_codes etc. and will need an options field passed to fix this. This is a note to come back to that when there is more time to fix it. 