### PR TITLE
noBids and noSuccessfulPanels filters added

### DIFF
--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -279,7 +279,12 @@ const addNoSuccessfulPanelFilter = (qb, value) => {
   if (value) {
     qb.leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
     if (value === 'Y') {
-      qb.whereNot('bs_cd', 'P')
+      qb.whereNotIn('employees.perdet_seq_num', function() {
+        this.select('employees.perdet_seq_num')
+          .from('employees')
+          .leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
+          .where('bs_cd', 'P')
+      })
     } else {
       qb.where('bs_cd', 'P')
     }

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -293,7 +293,7 @@ const addNoSuccessfulPanelFilter = (qb, value) => {
 
 const addNoBidsFilter = (qb, value) => {
   if (value) {
-    qb.leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
+    // qb.leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
     if (value === 'Y') {
       qb.whereNotIn('employees.perdet_seq_num', function() {
         this.select('employees.perdet_seq_num')
@@ -402,7 +402,7 @@ const get_paged_employees_by_query = async (query, mapping) => {
   try {
     const data = await get_employees_query(query, mapping).fetchPage({
       ...FETCH_OPTIONS,
-      pageSize: query["request_params.page_size"] || 25,
+      pageSize: query["request_params.page_size"] || 2000,
       page: query["request_params.page_index"] || 1
     })
     return data.serialize()

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -293,6 +293,7 @@ const addNoSuccessfulPanelFilter = (qb, value) => {
 
 const addNoBidsFilter = (qb, value) => {
   if (value) {
+    qb.leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
     if (value === 'Y') {
       qb.whereNotIn('employees.perdet_seq_num', function() {
         this.select('employees.perdet_seq_num')

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -293,7 +293,6 @@ const addNoSuccessfulPanelFilter = (qb, value) => {
 
 const addNoBidsFilter = (qb, value) => {
   if (value) {
-    // qb.leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
     if (value === 'Y') {
       qb.whereNotIn('employees.perdet_seq_num', function() {
         this.select('employees.perdet_seq_num')

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -295,12 +295,18 @@ const addNoBidsFilter = (qb, value) => {
   if (value) {
     qb.leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
     if (value === 'Y') {
-      qb.whereNotExists(function() {
-        this.select('employees.perdet_seq_num').from('employees').whereRaw('employees.perdet_seq_num = bids.perdet_seq_num');
+      qb.whereNotIn('employees.perdet_seq_num', function() {
+        this.select('employees.perdet_seq_num')
+          .from('employees')
+          .leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
+          .whereIn('bs_cd', ['A', 'C', 'P']);
       })
     } else {
-      qb.whereExists(function() {
-        this.select('employees.perdet_seq_num').from('employees').whereRaw('employees.perdet_seq_num = bids.perdet_seq_num');
+      qb.whereIn('employees.perdet_seq_num', function() {
+        this.select('employees.perdet_seq_num')
+          .from('employees')
+          .leftJoin('bids', 'employees.perdet_seq_num', 'bids.perdet_seq_num')
+          .whereIn('bs_cd', ['A', 'C', 'P']);
       })
     }
   }


### PR DESCRIPTION
Dual Merge: [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/1324)
 [BE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/466)

noBids Y: returns employees that have no bids with statuses of A, C, or P
noBids N: return employees with at least one bid with a status of A, C, or P

noSuccessfulPanel Y: return employees that have no bids with bid status(bs_cd) P
noSuccessfulPanel N: return employees that have at least one bid with bid status(bs_cd) P