### PR TITLE
Expose hs_cd, no_bids, and no_successful_panel in the /CDOClients payload

### DIFF
--- a/src/models/employees.js
+++ b/src/models/employees.js
@@ -11,6 +11,20 @@ const Employees = bookshelf.model('Employees', {
         return 'N'
       }
    },
+   no_bids: function() {
+        if (this.related('bids').pluck('bs_cd').some(b => ['A', 'C', 'P'].indexOf(b) > -1)) {
+          return 'N'
+        } else {
+          return 'Y'
+        }
+    },
+    no_successful_panel: function() {
+      if (this.related('bids').pluck('bs_cd').some(b => ['P'].indexOf(b) > -1)) {
+        return 'N'
+      } else {
+        return 'Y'
+      }
+  },
    fullname: function() {
      return `${this.get('last_name')}, ${this.get('first_name')}`
    }

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -135,6 +135,9 @@ const get_clients = async query => {
         rnum: index + 1,
         hru_id: manager.hru_id,
         rl_cd: roles.length > 0 ? roles[0]['code'] : '', // FSBid only returns one role
+        hs_cd: emp.hs_cd,
+        no_bids: emp.no_bids,
+        no_successful_panel: emp.no_successful_panel,
         employee: {
           perdet_seq_num: emp.perdet_seq_num,
           pert_external_id: `${emp.per_seq_num}`,


### PR DESCRIPTION
We've always been able to filter by these, but have never returned them in the payload. Don't merge until these are actually exposed by web services.