### PR TITLE
Upgrade postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ORACLE_HOST=host.docker.internal:1521/oraclepdb
       - DEBUG=false
   db:
-    image: postgres:9.6.3
+    image: postgres:13.4-alpine
     ports:
       - "35432:5432"
     volumes:


### PR DESCRIPTION
Postgres 9 is being deprecated in AWS. Upgrading to a version that AWS also offers.

https://forums.aws.amazon.com/ann.jspa?annID=8499