### PR TITLE
Feature/capsule description

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -684,6 +684,15 @@ var appRouter = function (app) {
       res.status(500).send({ "Message": "An error has occurred." });
     }
   })
+
+  app.get('/v1/publishablePositions/capsule', async function(req, res) {
+    try {
+      res.status(200).send(await positions.get_publishable_position_capsule(req.query))
+    } catch (errMsg) {
+      console.error(errMsg)
+      res.status(500).send({ "Message": "An error has occurred." });
+    }
+  }) 
 };
 
 module.exports = appRouter;

--- a/src/routes.js
+++ b/src/routes.js
@@ -693,6 +693,14 @@ var appRouter = function (app) {
       res.status(500).send({ "Message": "An error has occurred." });
     }
   }) 
+  
+   app.patch('/v1/publishablePositions/capsule', async function(req, res) {
+    const { query } = req
+    if (!(query.pos_seq_num && query.capsule_descr_txt && query.update_id && query.update_date)) {
+      res.status(200).send({ Data: null, usl_id: 4000003, return_code: -2 })
+    };
+    return res.status(200).send(await positions.update_capsule_description(query))
+  }); 
 };
 
 module.exports = appRouter;

--- a/src/services/positions.js
+++ b/src/services/positions.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 
 const { Positions } = require('../models')
+const { CapsuleDescription } = require('../models')
 const { formatLanguage } = require('./common')
 
 
@@ -119,4 +120,27 @@ async function get_position_by_pos_num(query) {
   }
 }
 
-module.exports = { get_position_by_id, get_position_by_pos_num }
+const formatCapsule = (data) => {
+  if (data) {
+    return [data].map(d => {
+      return {
+        "pos_seq_num": d.pos_seq_num,
+        "capsule_descr_txt": d.description,
+        "capsule_modify_date": d.last_modified, 
+        "update_id": 33155,
+        "update_date": "20210908125141"
+      }
+    })
+  }
+}
+
+async function get_publishable_position_capsule(query) {
+  const data = await new CapsuleDescription({ pos_seq_num: query.pos_seq_num }).fetch()
+  return {
+    "Data": formatCapsule(data.serialize()),
+    "usl_id": 44999637,
+    "return_code": 0
+  }
+}
+
+module.exports = { get_position_by_id, get_position_by_pos_num, get_publishable_position_capsule }

--- a/src/services/positions.js
+++ b/src/services/positions.js
@@ -143,4 +143,18 @@ async function get_publishable_position_capsule(query) {
   }
 }
 
-module.exports = { get_position_by_id, get_position_by_pos_num, get_publishable_position_capsule }
+async function update_capsule_description(query) {
+  let ReturnCode  
+  try {
+    await CapsuleDescription.where('pos_seq_num', query.pos_seq_num).save({
+      description: query.capsule_descr_txt
+    }, {patch: true})
+    ReturnCode = 0   
+  } catch (Error) {
+    console.log(`An error occurred updating capsule description... ${Error}`)
+    ReturnCode = -2
+  }
+  return { Data: null, usl_id: 45066084, ReturnCode }
+}
+
+module.exports = { get_position_by_id, get_position_by_pos_num, get_publishable_position_capsule, update_capsule_description }


### PR DESCRIPTION
Notes:
ReturnCode 🤮 
`-2` vs `0` for failure/success
Required fields check
GET endpoint sets static required fields not currently tracked for GET/PATCH workflow