### PR TITLE
TM-4032, update mock data for agenda employee to reflect dev1 data

### DIFF
--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -801,7 +801,13 @@ const get_v3_persons_agenda_items = async query => {
             }
           ] : [],
           handshake: [],
-          cdos: [{ hruid: 1 }]
+          cdo: [
+            {
+              echruid: 3,
+              ecperdetseqnum: 383517,
+              ecrlcd: "CDO"
+            }
+          ]
         }
         return res
       }))

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -753,6 +753,7 @@ const get_v3_persons_agenda_items = async query => {
     const getAgendas = await agendas.getAgendas(data)
 
     const mapData = Promise.all(data.map(async (emp) => {
+      const getCDO = await get_employee_by_perdet_seq_num(emp.manager_id)
         const {
           roles = [],
           manager = [],
@@ -801,13 +802,14 @@ const get_v3_persons_agenda_items = async query => {
             }
           ] : [],
           handshake: [],
-          cdo: [
-            {
-              echruid: 3,
-              ecperdetseqnum: 383517,
+          cdo: getCDO.length === 0
+            ? []
+            :
+            [{
+              echruid: getCDO[0].hru_id,
+              ecperdetseqnum: getCDO[0].perdet_seq_num,
               ecrlcd: "CDO"
-            }
-          ]
+            }]
         }
         return res
       }))

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -753,7 +753,6 @@ const get_v3_persons_agenda_items = async query => {
     const getAgendas = await agendas.getAgendas(data)
 
     const mapData = Promise.all(data.map(async (emp) => {
-      const getCDO = await get_employee_by_perdet_seq_num(emp.manager_id)
         const {
           roles = [],
           manager = [],
@@ -802,14 +801,14 @@ const get_v3_persons_agenda_items = async query => {
             }
           ] : [],
           handshake: [],
-          cdo: getCDO.length === 0
-            ? []
-            :
+          cdo: emp.manager
+            ?
             [{
-              echruid: getCDO[0].hru_id,
-              ecperdetseqnum: getCDO[0].perdet_seq_num,
+              echruid: emp.manager.hru_id,
+              ecperdetseqnum: emp.manager.perdet_seq_num,
               ecrlcd: "CDO"
             }]
+            : []
         }
         return res
       }))


### PR DESCRIPTION
DEV1 has this object looking like so ... 
no CDO will return a blank array 
<img width="361" alt="image" src="https://user-images.githubusercontent.com/12723877/222924358-f946001d-5c80-46c0-923d-500d3a47552f.png">


and this is how the API handles the data (it doesn't seem like a change needs to be made there)
<img width="448" alt="image" src="https://user-images.githubusercontent.com/12723877/222924398-b6fb59af-8363-401e-822f-f9b219fd34e7.png">
Though it does seem to assume `echruid` maps directly to the `hru_id` in the employee/CDO list  ... 🤔


Before/After
<img width="431" alt="image" src="https://user-images.githubusercontent.com/12723877/222924560-9f25c831-427b-4915-a057-730a4a0f91f6.png">
<img width="372" alt="image" src="https://user-images.githubusercontent.com/12723877/222924535-8220c9c4-ddcf-4504-b1e1-5107b2539cac.png">
